### PR TITLE
Allow paths to change at runtime

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wiggly-games/markov-chains",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "",
     "main": "main.js",
     "types": "main.d.ts",

--- a/interfaces/IData.ts
+++ b/interfaces/IData.ts
@@ -14,6 +14,7 @@
         GetCount(sequence: string): number -> Returns the number of words that can be linked from the preceding sequence.
 
     For Persistence:
+        SetPaths(path: string): Sets a folder directory where will be loaded/unloaded from.
         Connect(): Connects to file to load in data.
         Disconnect(): Disconnects, cleans up memory use, and saves everything to file.
 */
@@ -26,7 +27,7 @@ export interface IData {
     GetStartKey(): Promise<string>;
     AddStartingKey(key: string): Promise<void>;
 
-    // Connects/Disconnects from file system for persistent data storage.
+    SetPaths(path: string): void;
     Connect(): Promise<void>;
     Disconnect(): Promise<void>;
 }

--- a/interfaces/IMarkovChain.ts
+++ b/interfaces/IMarkovChain.ts
@@ -1,4 +1,4 @@
 export interface IMarkovChain {
-    Train(data: string): Promise<void>;
-    Generate(): Promise<string>;
+    Train(data: string, path: string): Promise<void>;
+    Generate(path: string): Promise<string>;
 }

--- a/main.ts
+++ b/main.ts
@@ -8,17 +8,25 @@ import { ProbabilityMap } from "./src";
 
 export class MarkovChain implements IMarkovChain {
     _chain: IData;
-    constructor(path: string) {
+    constructor() {
+        // Create the data list
+        this._chain = new DataList((data?: Map<any, number>)=>new ProbabilityMap(data));
+    }
+    async Train(data: string, outputPath: string) {
+        this.SetPaths(outputPath);
+        await Train(this._chain, data);
+    }
+    async Generate(inputPath: string): Promise<string> {
+        this.SetPaths(inputPath);
+        return await Generate(this._chain);
+    }
+
+    // Sets the path to the folder to be used for persistent storage within the chain.
+    protected SetPaths(path: string) {
         // If the directory doesn't already exist, create a new one
         CreateDirectory(path);
 
-        // Create the data list
-        this._chain = new DataList(path, (data?: Map<any, number>)=>new ProbabilityMap(data));
-    }
-    async Train(data: string) {
-        await Train(this._chain, data);
-    }
-    async Generate(): Promise<string> {
-        return await Generate(this._chain);
+        // Set the path to be used by the chain
+        this._chain.SetPaths(path);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wiggly-games/markov-chains",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "",
     "main": "build/main.js",
     "types": "build/main.d.ts",

--- a/src/Data/DataList.ts
+++ b/src/Data/DataList.ts
@@ -16,16 +16,18 @@ export class DataList implements IData  {
         Data: string;
     }
 
-    constructor(path: string, getProbabilityMap: (data?: Map<any, number>)=>IProbabilityMap<string>) {
+    constructor(getProbabilityMap: (data?: Map<any, number>)=>IProbabilityMap<string>) {
         this._list = undefined;
         this._startingKeys = undefined;
         this._getProbabilityMap = getProbabilityMap;
-
+    }
+    SetPaths(path: string) {
         this._paths = {
             StartingKeys: `${path}\\StartingKeys.json`,
             Data: `${path}\\Data.json`
         }
     }
+
     GetCount(sequence: string): Promise<number> {
         return Promise.resolve(this._list.has(sequence) ? this._list.get(sequence).GetCount() : 0);
     }
@@ -60,6 +62,7 @@ export class DataList implements IData  {
 
     // Connects to the file system to load the memory data.
     async Connect() {
+        console.assert(this._paths !== undefined, "Chain failed to connect; no paths specified.");
         const startingKeys = await Files.LoadJson(this._paths.StartingKeys, LoadWithProbabilityMap(this._getProbabilityMap));
         const dataList = await Files.LoadJson(this._paths.Data, LoadWithProbabilityMap(this._getProbabilityMap));
 
@@ -78,6 +81,8 @@ export class DataList implements IData  {
 
     // Disconnects from the file system, stores the data from memory to file, and closes the lists.
     async Disconnect() {
+        console.assert(this._paths !== undefined, "Chain failed to disconnect; could not find output path.");
+
         // Write the data to file
         await Files.Overwrite(this._paths.StartingKeys, JSON.stringify(this._startingKeys, SaveWithMaps));
         await Files.Overwrite(this._paths.Data, JSON.stringify(this._list, SaveWithMaps));

--- a/test.ts
+++ b/test.ts
@@ -2,10 +2,12 @@ import { MarkovChain } from "./main";
 import * as TestData from "./TestData/WeirdAl.json"
 
 (async () => {
-    const chain = new MarkovChain(require.main.path + "\\Static");
-    //await chain.Train(TestData.join("\n"))
+    const path = require.main.path + "\\Static";
+
+    const chain = new MarkovChain();
+    //await chain.Train(TestData.join("\n"), path + "2")
     
     for (let i = 0; i < 100; i++) {
-        console.log(await chain.Generate());
+        console.log(await chain.Generate(path));
     }
 })()


### PR DESCRIPTION
Moves the path into the Generate and Train methods, so that we can dynamically change them at runtime.