### PR TITLE
Add TInternal type

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -6,7 +6,8 @@
     "types": "types/main.d.ts",
     "scripts": {
       "start": "node main.js",
-      "test": "node --expose-gc test.js"
+      "train": "node --expose-gc test.js -- mode=train",
+      "generate": "node --expose-gc test.js -- mode=generate"
     },
     "author": "",
     "license": "ISC",

--- a/build/package.json
+++ b/build/package.json
@@ -6,7 +6,7 @@
     "types": "types/main.d.ts",
     "scripts": {
       "start": "node main.js",
-      "test": "node test.js"
+      "test": "node --expose-gc test.js"
     },
     "author": "",
     "license": "ISC",

--- a/interfaces/IData.ts
+++ b/interfaces/IData.ts
@@ -24,14 +24,16 @@
         Load(): Loads the data from a file, allowing it to be used for generating chains.
 */
 
+import { TInternal } from "../src";
+
 export interface IData {
-    GetCount(sequence: number[]): Promise<number>;
-    Get(sequence: number[]): Promise<number | undefined>;
-    Add(sequence: number[], next: number): Promise<void>;
+    GetCount(sequence: TInternal[]): Promise<number>;
+    Get(sequence: TInternal[]): Promise<TInternal | undefined>;
+    Add(sequence: TInternal[], next: TInternal): Promise<void>;
 
-    GetStartKey(): Promise<number>;
-    AddStartingKey(key: number): Promise<void>;
+    GetStartKey(): Promise<TInternal>;
+    AddStartingKey(key: TInternal): Promise<void>;
 
-    GetStartingKeys(): [number, number][];
-    GetData(): [string, [number, number][]][];
+    GetStartingKeys(): [TInternal, number][];
+    GetData(): [string, [TInternal, number][]][];
 }

--- a/interfaces/ITypeMapping.ts
+++ b/interfaces/ITypeMapping.ts
@@ -3,10 +3,12 @@
     This allows us to store all our data as numbers, and then parse them back into the origin values later.
 */
 
+import { TInternal } from "../src";
+
 export interface ITypeMapping<T> {
     Set(values: T[]): void;
     Update(values: T[]): void;
-    GetValue(data: T): number;
-    Parse(value: number): T;
+    GetValue(data: T): TInternal;
+    Parse(value: TInternal): T;
     GetAllValues(): T[];
 }

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@
 */
 
 import { IData, IMarkovChain, ITypeMapping } from "./interfaces";
-import { DataList, Generate, Train, TConfiguration } from "./src";
+import { DataList, Generate, Train, TConfiguration, TInternal } from "./src";
 import { CreateDirectory, WithReadStream, Overwrite } from "@wiggly-games/files";
 import { Bag, IBag } from "@wiggly-games/data-structures";
 import { Encoder, Decoder } from "@msgpack/msgpack";
@@ -86,7 +86,7 @@ export class MarkovChain<T> implements IMarkovChain<T> {
     }
 
     // Given a list of numbers, returns the data value representation.
-    private ParseOutputData(output: number[]): T[] {
+    private ParseOutputData(output: TInternal[]): T[] {
         const result = [];
         output.forEach(value => {
             result.push(this._mapping.Parse(value));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "compile": "tsc",
         "dev": "npm run compile && npm start",
         "start": "cd build && npm start",
-        "test": "npm run compile && cd build && npm run test",
+        "train": "npm run compile && cd build && npm run train",
+        "generate": "npm run compile && cd build && npm run generate",
         "sandbox": "cd build && node",
         "clean": "rmdir /S /Q \"build/Logs/LogFiles\"",
         "zip": "tar.exe -a -c -f build.zip build"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "dev": "npm run compile && npm start",
         "start": "cd build && npm start",
         "test": "npm run compile && cd build && npm run test",
-        "gc": "npm run compile && cd build && node --expose-gc ./test.js",
         "sandbox": "cd build && node",
         "clean": "rmdir /S /Q \"build/Logs/LogFiles\"",
         "zip": "tar.exe -a -c -f build.zip build"

--- a/src/Data/DataList.ts
+++ b/src/Data/DataList.ts
@@ -6,10 +6,9 @@ import { IData } from "../../interfaces";
 import * as Files from "@wiggly-games/files";
 import { Bag, IBag } from "@wiggly-games/data-structures";
 import { MarkovChain } from "../../main";
+import { CreateKeyFromSequence } from "../Helpers";
 
 // Parses a sequence of numbers into a key for the data array.
-const parseToKey = (sequence: any[]) => sequence.join(".");
-
 export class DataList implements IData  {
     protected _list: Map<string, IBag<any>>;
     protected _startingKeys: IBag<any>;
@@ -40,11 +39,11 @@ export class DataList implements IData  {
     }
 
     GetCount(sequence: any[]): Promise<any> {
-        const key = parseToKey(sequence);
+        const key = CreateKeyFromSequence(sequence);
         return Promise.resolve(this._list.has(key) ? this._list.get(key).CountContents() : 0);
     }
     async Get(sequence: any[]): Promise<any | undefined> {
-        const key = parseToKey(sequence);
+        const key = CreateKeyFromSequence(sequence);
         let results = this._list.get(key);
     
         // If there is no next word for this sequence, return nothing.
@@ -56,7 +55,7 @@ export class DataList implements IData  {
     }
     Add(sequence: any[], next: any): Promise<void> {
         const list = this._list;
-        const key = parseToKey(sequence);
+        const key = CreateKeyFromSequence(sequence);
 
         // If we haven't already seen this sequence, start a new list.
         if (!list.has(key)) {

--- a/src/Helpers/Arrays.ts
+++ b/src/Helpers/Arrays.ts
@@ -4,5 +4,8 @@
         - Retrieves the ending sequence from a chain, given the length of words to include.
 */
 
+const splitter = String.fromCharCode(1);
+
 export const ClearBlanks = (x: string[]) => x.filter(x => x !== "");
 export const GetEndSequence = (sequence: any[], chainLength: number) => sequence.slice(-chainLength);
+export const CreateKeyFromSequence = (sequence: any[]) => sequence.join(splitter);

--- a/src/Mapping/TypeMapping.ts
+++ b/src/Mapping/TypeMapping.ts
@@ -1,4 +1,5 @@
 import { ITypeMapping } from "../../interfaces";
+import { TInternal } from "../Types";
 
 export class TypeMapping<T> implements ITypeMapping<T> {
     private _values: T[];
@@ -31,12 +32,13 @@ export class TypeMapping<T> implements ITypeMapping<T> {
     }
     
     // Retrieves the numerical value for a piece of data.
-    GetValue(data: T): number {
-        return this._map.get(data);
+    GetValue(data: T): TInternal {
+        const index = this._map.get(data);
+        return index;
     }
 
     // Returns the data value given its numerical representation.
-    Parse(value: number): T {
+    Parse(value: TInternal): T {
         return this._values[value];
     }
 

--- a/src/Types/TInternal.ts
+++ b/src/Types/TInternal.ts
@@ -1,0 +1,3 @@
+// Represents the Internal Value data type, used for representing values in the chain.
+// Converts to/from input/output using the TMapping class.
+export type TInternal = number;

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -1,1 +1,2 @@
 export * from "./TConfiguration";
+export * from "./TInternal";

--- a/test.ts
+++ b/test.ts
@@ -6,7 +6,7 @@ import { ClearBlanks } from "./src/Helpers";
 import * as Files from "@wiggly-games/files";
 import * as os from "os";
 
-const log = "./Logs-3.txt";
+let log: string;
 const delayAmnt = 10;
 
 const start = new Date().getTime();
@@ -33,20 +33,7 @@ function writeLog(txt: string) {
     console.log(txt);
 }
 
-async function main(){
-    const path = require.main.path + "\\Static\\Wiggles";
-    CreateDirectory(require.main.path + "\\Static");
-
-    const chain = new MarkovChain<string>(path, {
-        WordCount: 50,
-        Backoff: true,
-        MinBackoffLength: 2,
-        TrainingLength: 5,
-        MinRequiredOptions: 3,
-        StopAtFewerOptions: false
-    });
-
-    
+async function train(chain: MarkovChain<string>){
     const input = TestData as string[];
     const trainingData: string[][] = [];
 
@@ -63,15 +50,15 @@ async function main(){
     writeLog(`Finished training.`);
     global.gc();
     await delay(delayAmnt);
-
-
+    
     writeLog(`Started saving.`);
     await chain.Save();
     writeLog(`Finished saving.`);
     global.gc();
     await delay(delayAmnt);
-    
-    /*
+}
+
+async function generate(chain: MarkovChain<string>){
     writeLog(`Starting loading.`);
     await chain.Load();
     writeLog(`Finished loading.`);
@@ -85,11 +72,55 @@ async function main(){
         await delay(1);
     }
     writeLog(`Stopped generating.`);
-    */
 }
 
-(async () => {
-    //await main();
-    global.gc();
-    console.log("garbage collected");
-})();
+async function main(mode: number){
+    const path = require.main.path + "\\Static\\Wiggles-Str";
+    CreateDirectory(require.main.path + "\\Static");
+
+    const chain = new MarkovChain<string>(path, {
+        WordCount: 50,
+        Backoff: true,
+        MinBackoffLength: 2,
+        TrainingLength: 5,
+        MinRequiredOptions: 3,
+        StopAtFewerOptions: false
+    });
+
+    if (mode === 0) {
+        await generate(chain);
+    } else {
+        await train(chain);
+    }
+
+    clearInterval(interval);
+}
+
+const mode = process.argv.find(x => x.startsWith("mode=")).substring(5);
+const output = process.argv.find(x => x.startsWith("out=")).substring(4);
+log = output ?? "./log.txt";
+console.log(`Writing logs to file: ${log}`);
+
+if (!global.gc) {
+    console.error(`Test script requires the --expose-gc command line argument.`);
+    console.error(`Please run again with the argument provided.`);
+} else {
+    switch (mode) {
+        case "generate":
+        case "g":
+        case "0":
+            console.log("generate");
+            main(0);
+            break;
+        case "train":
+        case "t":
+        case "1":
+            console.log("train");
+            main(1);
+            break;
+        default:
+            console.warn(`Unknown mode: ${mode}; please enter 'train' or 'generate'`);
+            clearInterval(interval);
+            break;
+    }
+}

--- a/test.ts
+++ b/test.ts
@@ -96,8 +96,8 @@ async function main(mode: number){
     clearInterval(interval);
 }
 
-const mode = process.argv.find(x => x.startsWith("mode=")).substring(5);
-const output = process.argv.find(x => x.startsWith("out=")).substring(4);
+const mode = process.argv.find(x => x.startsWith("mode="))?.substring(5);
+const output = process.argv.find(x => x.startsWith("out="))?.substring(4);
 log = output ?? "./log.txt";
 console.log(`Writing logs to file: ${log}`);
 
@@ -109,13 +109,11 @@ if (!global.gc) {
         case "generate":
         case "g":
         case "0":
-            console.log("generate");
             main(0);
             break;
         case "train":
         case "t":
         case "1":
-            console.log("train");
             main(1);
             break;
         default:

--- a/test.ts
+++ b/test.ts
@@ -75,7 +75,7 @@ async function generate(chain: MarkovChain<string>){
 }
 
 async function main(mode: number){
-    const path = require.main.path + "\\Static\\Wiggles-Str";
+    const path = require.main.path + "\\Static\\Wiggles";
     CreateDirectory(require.main.path + "\\Static");
 
     const chain = new MarkovChain<string>(path, {


### PR DESCRIPTION
Adds a type that can be used for the internal data representation.

Also updates the test script, so that we can set which mode to use (train/generate) from the command line.