### PR TITLE
Allow for passing in a phrase to base generation off of

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -8,7 +8,7 @@
       "start": "node main.js",
       "train": "node --expose-gc test.js -- mode=train",
       "generate": "node --expose-gc test.js -- mode=generate",
-      "gc": "node --expose-gc test.js -- mode=gc"
+      "gen-2": "node --expose-gc test.js -- mode=phrase"
     },
     "author": "",
     "license": "ISC",

--- a/interfaces/IMarkovChain.ts
+++ b/interfaces/IMarkovChain.ts
@@ -7,5 +7,5 @@
 
 export interface IMarkovChain<T> {
     Train(data: T[][]): Promise<void>;
-    Generate(): Promise<T[]>;
+    Generate(startingSequence?: T[] | undefined): Promise<T[]>;
 }

--- a/main.ts
+++ b/main.ts
@@ -37,9 +37,18 @@ export class MarkovChain<T> implements IMarkovChain<T> {
     }
 
     // Generates data from the chain.
-    async Generate(): Promise<T[]> {
+    async Generate(startingSequence?: T[] | undefined): Promise<T[]> {
+        // if a starting sequence isn't passed in, initialize it with an empty array
+        if (startingSequence === undefined) {
+            startingSequence = [];
+        }
+
+        // convert the data into the internal format
+        this._mapping.Update(startingSequence);
+        let initData = this.ConvertInputSet(startingSequence);
+
         // Retrieve the numerical representation values
-        const output = await Generate(this._chain, this._configuration);
+        const output = await Generate(this._chain, this._configuration, initData);
 
         // Build them up into the actual data values, so that we can return it to the user
         // in their expected format
@@ -77,11 +86,14 @@ export class MarkovChain<T> implements IMarkovChain<T> {
     private ConvertInputData(input: T[][]): number[][] {
         const result = [ ];
         input.forEach((inputSet) => {
-            const next = [ ];
-            inputSet.forEach(value => {
-                next.push(this._mapping.GetValue(value));
-            })
-            result.push(next);
+            result.push(this.ConvertInputSet(inputSet));
+        });
+        return result;
+    }
+    private ConvertInputSet(input: T[]): number[] {
+        const result = [ ];
+        input.forEach(value => {
+            result.push(this._mapping.GetValue(value));
         });
         return result;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "start": "cd build && npm start",
         "train": "npm run compile && cd build && npm run train",
         "generate": "npm run compile && cd build && npm run generate",
-        "gc": "npm run compile && cd build && npm run gc",
+        "gen-2": "npm run compile && cd build && npm run gen-2",
         "sandbox": "cd build && node",
         "clean": "rmdir /S /Q \"build/Logs/LogFiles\"",
         "zip": "tar.exe -a -c -f build.zip build"

--- a/test.ts
+++ b/test.ts
@@ -58,26 +58,16 @@ async function train(chain: MarkovChain<string>){
     await delay(delayAmnt);
 }
 
-async function generate(chain: MarkovChain<string>, gc: boolean){
+async function generate(chain: MarkovChain<string>, seq?: string[]){
     const start = new Date().getTime();
-
-    writeLog(`Starting loading.`);
-    await chain.Load((x) => x);
-    writeLog(`Finished loading. Loaded in ${new Date().getTime() - start} ms.`);
+    chain.Load((x) => x);
 
     await delay(delayAmnt);
     writeLog(`Started generating.`);
 
-    let count = gc ? 10000 : 50;
-    for (let i = 0; i < count; i++) {
-        let res = await chain.Generate();
-        if (gc){
-            global.gc();
-            await delay(1);
-        } else {
-            console.log(res.join(" "));
-        }
-    }
+    let res = await chain.Generate(seq);
+    console.log(res);
+
     writeLog(`Stopped generating.`);
 }
 
@@ -95,11 +85,11 @@ async function main(mode: number){
     });
 
     if (mode === 0) {
-        await generate(chain, false);
+        await generate(chain);
     } else if (mode === 1) {
         await train(chain);
     } else {
-        await generate(chain, true);
+        await generate(chain);
     }
 
     clearInterval(interval);
@@ -125,7 +115,7 @@ if (!global.gc) {
         case "1":
             main(1);
             break;
-        case "gc":
+        case "phrase":
             main(2);
             break;
         default:

--- a/test.ts
+++ b/test.ts
@@ -1,6 +1,6 @@
 import { Bag } from "@wiggly-games/data-structures";
 import { MarkovChain } from "./main";
-import * as TestData from "./TestData/Wiggles.json"
+import * as TestData from "./TestData/WeirdAl.json"
 import { CreateDirectory } from "@wiggly-games/files";
 import { ClearBlanks } from "./src/Helpers";
 import * as Files from "@wiggly-games/files";


### PR DESCRIPTION
Rather than assuming generating should always start with a new phrase, this allows us to pass in a phrase and build generated data off of that phrase. Will default to building new phrase if generation fails (no matches), in which case the starting phrase is pre-pended with the generated data.